### PR TITLE
feat: Theme

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ThemeService } from './theme.service';
 
 @Component({
   selector: 'app-root',
@@ -7,5 +8,6 @@ import { RouterOutlet } from '@angular/router';
   template: '<router-outlet />',
 })
 export class AppComponent {
+  constructor(public themeService: ThemeService) {}
   title = 'library';
 }

--- a/src/app/theme.service.spec.ts
+++ b/src/app/theme.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ThemeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -1,0 +1,60 @@
+import {
+  Injectable,
+  OnDestroy,
+  Renderer2,
+  RendererFactory2,
+} from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThemeService implements OnDestroy {
+  private currentTheme: 'light' | 'dark' = 'light';
+  private renderer: Renderer2;
+  private mediaQueryListener: ((event: MediaQueryListEvent) => void) | null =
+    null;
+
+  constructor(private rendererFactory: RendererFactory2) {
+    this.renderer = this.rendererFactory.createRenderer(null, null);
+    this.detectDeviceTheme();
+  }
+
+  setTheme(theme: 'light' | 'dark'): void {
+    this.currentTheme = theme;
+    this.renderer.setAttribute(
+      document.documentElement,
+      'data-bs-theme',
+      theme
+    );
+  }
+
+  detectDeviceTheme(): void {
+    if (window.matchMedia) {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      this.handleDeviceThemeChange(mediaQuery);
+      this.mediaQueryListener = (event) => {
+        this.handleDeviceThemeChange(event);
+      };
+      mediaQuery.addEventListener('change', this.mediaQueryListener);
+    }
+  }
+
+  private handleDeviceThemeChange(event: MediaQueryList | MediaQueryListEvent) {
+    if (event.matches) {
+      this.setTheme('dark');
+    } else {
+      this.setTheme('light');
+    }
+  }
+
+  get currentThemeValue(): 'light' | 'dark' {
+    return this.currentTheme;
+  }
+
+  ngOnDestroy(): void {
+    if (this.mediaQueryListener) {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      mediaQuery.removeEventListener('change', this.mediaQueryListener);
+    }
+  }
+}


### PR DESCRIPTION
Resolves #10 

This PR implements Bootstrap dark/light mode theme switching based on device settings.

If the user's device color scheme is set to light, the interface uses the light theme.

If the user's device color scheme is set to dark, the interface uses the dark theme.

To accomplish this I created a new theme service to detect device setting and device changes. This service sets the `data-bs-theme` document attribute to "dark" or "light".