### PR TITLE
feat: Navbar

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -92,5 +92,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ThemeService } from './theme.service';
+import { NavbarComponent } from './shared/components/navbar/navbar.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
-  template: '<router-outlet />',
+  imports: [RouterOutlet, NavbarComponent],
+  template: `<app-navbar /> <router-outlet />`,
 })
 export class AppComponent {
   constructor(public themeService: ThemeService) {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,12 +1,45 @@
-import { Routes } from '@angular/router';
+import { Route, Routes } from '@angular/router';
 import { ListComponent } from './pages/list/list.component';
 import { BookSearchComponent } from './pages/book-search/book-search.component';
 import { BookDetailsComponent } from './pages/book-details/book-details.component';
 import { ScanComponent } from './pages/scan/scan.component';
 
-export const routes: Routes = [
-  { path: '', component: ListComponent },
-  { path: 'search', component: BookSearchComponent },
-  { path: 'books/:isbn', component: BookDetailsComponent },
-  { path: 'scan', component: ScanComponent },
+export interface AppRoute extends Route {
+  title: string;
+  data?: {
+    /**
+     * Whether to show this route in the navbar
+     * @type {boolean | undefined}
+     * @default undefined
+     * @example
+     * ```ts
+     * data: {
+     *  showInNavbar: true,
+     * }
+     */
+    showInNavbar?: boolean;
+  };
+}
+
+export const routes: AppRoute[] = [
+  {
+    title: 'Library',
+    path: '',
+    component: ListComponent,
+  },
+  {
+    title: 'Add Book',
+    path: 'search',
+    component: BookSearchComponent,
+  },
+  {
+    title: 'Book Details',
+    path: 'books/:isbn',
+    component: BookDetailsComponent,
+  },
+  {
+    title: 'Scan',
+    path: 'scan',
+    component: ScanComponent,
+  },
 ];

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -1,0 +1,1 @@
+<p>navbar works!</p>

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -1,1 +1,27 @@
-<p>navbar works!</p>
+<nav class="navbar navbar-expand-lg bg-body-tertiary sticky-top">
+  <div class="container">
+    <a class="navbar-brand" href="/">Library</a>
+    @if(routes.length > 0){
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-bs-toggle="collapse"
+      data-bs-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        @for (route of routes; track route.path){
+        <li class="nav-item">
+          <a class="nav-link" href="{{ route.path }}">{{ route.title }}</a>
+        </li>
+        }
+      </ul>
+    </div>
+    }
+  </div>
+</nav>

--- a/src/app/shared/components/navbar/navbar.component.spec.ts
+++ b/src/app/shared/components/navbar/navbar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavbarComponent } from './navbar.component';
+
+describe('NavbarComponent', () => {
+  let component: NavbarComponent;
+  let fixture: ComponentFixture<NavbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NavbarComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(NavbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-navbar',
+  imports: [],
+  templateUrl: './navbar.component.html',
+  styleUrl: './navbar.component.css'
+})
+export class NavbarComponent {
+
+}

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -1,11 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { routes, AppRoute } from '../../../app.routes';
 
 @Component({
   selector: 'app-navbar',
   imports: [],
   templateUrl: './navbar.component.html',
-  styleUrl: './navbar.component.css'
+  styleUrl: './navbar.component.css',
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit {
+  routes: AppRoute[] = [];
 
+  ngOnInit() {
+    this.routes = routes.filter((route) => route.data?.showInNavbar);
+  }
 }


### PR DESCRIPTION
Resolves #15 

This PR introduces a new navbar component into the application. While it presently does not render any routes, it is useful for routing the user back to their library from any screen.

In future PRs, we can add routes to the navbar by adding relevant `showInNavbar` boolean as shown in the AppRoutes interface. ( _See_ `src/app/app.routes.ts` )

# Screenshot
![image](https://github.com/user-attachments/assets/bb0bdb2c-f362-47d1-bb4a-9baedeff2089)
